### PR TITLE
Add blog pages and navigation

### DIFF
--- a/content/blog/first-project.json
+++ b/content/blog/first-project.json
@@ -1,0 +1,10 @@
+{
+  "slug": "first-project",
+  "title": "My First Project",
+  "date": "2025-05-30",
+  "excerpt": "A quick intro to my first project...",
+  "body": [
+    "This is the first paragraph of the project post.",
+    "Here we talk more about the details of the project."
+  ]
+}

--- a/content/blog/second-project.json
+++ b/content/blog/second-project.json
@@ -1,0 +1,10 @@
+{
+  "slug": "second-project",
+  "title": "Another Great Project",
+  "date": "2025-06-15",
+  "excerpt": "An overview of my second big project...",
+  "body": [
+    "Opening paragraph for the second project.",
+    "Additional information about how it was built and lessons learned."
+  ]
+}

--- a/src/app/blog/[slug_title]/page.tsx
+++ b/src/app/blog/[slug_title]/page.tsx
@@ -1,0 +1,34 @@
+import { getAllSlugs, getPostBySlug } from '@/lib/blog';
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+
+export async function generateStaticParams() {
+  const slugs = await getAllSlugs();
+  return slugs.map((slug) => ({ slug_title: slug }));
+}
+
+export async function generateMetadata({ params }: { params: { slug_title: string } }): Promise<Metadata> {
+  const post = await getPostBySlug(params.slug_title);
+  return {
+    title: post ? `${post.title} | Metaswap` : 'Post Not Found',
+  };
+}
+
+export default async function BlogPostPage({ params }: { params: { slug_title: string } }) {
+  const post = await getPostBySlug(params.slug_title);
+  if (!post) return notFound();
+
+  return (
+    <main className="min-h-screen w-full px-6 py-20 bg-white text-black">
+      <Link href="/blog" className="underline mb-8 block">Back to Blog</Link>
+      <h1 className="text-6xl font-extrabold mb-4">{post.title}</h1>
+      <p className="text-sm mb-8">{post.date}</p>
+      <article className="space-y-4">
+        {post.body.map((paragraph, idx) => (
+          <p key={idx}>{paragraph}</p>
+        ))}
+      </article>
+    </main>
+  );
+}

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -1,0 +1,29 @@
+import { getAllPosts } from '@/lib/blog';
+import Link from 'next/link';
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Blog | Metaswap',
+};
+
+export default async function BlogPage() {
+  const posts = await getAllPosts();
+  return (
+    <main className="min-h-screen w-full px-6 py-20 bg-white text-black">
+      <h1 className="text-6xl font-extrabold mb-12">Blog</h1>
+      <div className="grid gap-8 md:grid-cols-2">
+        {posts.map((post) => (
+          <Link
+            key={post.slug}
+            href={`/blog/${post.slug}`}
+            className="block p-6 border border-black/10 shadow-sm hover:shadow-lg transition bg-white"
+          >
+            <h2 className="text-3xl font-bold mb-2">{post.title}</h2>
+            <p className="text-sm mb-4">{post.date}</p>
+            <p>{post.excerpt}</p>
+          </Link>
+        ))}
+      </div>
+    </main>
+  );
+}

--- a/src/app/careers/page.tsx
+++ b/src/app/careers/page.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Careers | Metaswap',
+};
+
+export default function CareersPage() {
+  return (
+    <main className="min-h-screen flex items-center justify-center bg-white">
+      <h1 className="text-6xl font-extrabold">Careers</h1>
+    </main>
+  );
+}

--- a/src/app/components/Header.tsx
+++ b/src/app/components/Header.tsx
@@ -1,45 +1,55 @@
-// src/app/components/Header.tsx
 "use client";
 
-import { UserIcon } from "@heroicons/react/24/solid";
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { Bars3Icon, XMarkIcon } from '@heroicons/react/24/solid';
+import { useState } from 'react';
+
+const links = [
+  { href: '/news', label: 'News' },
+  { href: '/about', label: 'About' },
+  { href: '/investors', label: 'Investors' },
+  { href: '/careers', label: 'Careers' },
+  { href: '/blog', label: 'Blog' },
+];
 
 export default function Header() {
-  return (
-    <header
-      className="
-      fixed top-0 left-0 w-full z-10
-      px-4 md:px-6 py-4
-      pt-20
-      flex items-center
-      justify-center md:justify-end
-      bg-transparent
-    "
-    >
-      {/* done */}
-      <nav className="flex items-center gap-5 md:gap-8">
-        <a
-          href="https://instagram.com/metaswap"
-          target="_blank"
-          className="underline underline-offset-4 decoration-2 text-2xl md:text-3xl font-bold"
-        >
-          News
-        </a>
-        <a
-          href="https://metaswap.xyz.com/about"
-          target="_blank"
-          className="underline underline-offset-4 decoration-2 text-2xl md:text-3xl font-bold"
-        >
-          About
-        </a>
-        <a
-          href="mailto:info@metaswapllc.com"
-          className="underline underline-offset-4 decoration-2 text-2xl md:text-3xl font-bold"
-        >
-          Investors
-        </a>
+  const pathname = usePathname();
+  const [open, setOpen] = useState(false);
 
-        <UserIcon className="h-6 w-6 md:h-8 md:w-8 text-black ml-2" />
+  const NavLink = ({ href, label }: { href: string; label: string }) => (
+    <Link
+      href={href}
+      onClick={() => setOpen(false)}
+      className={`underline underline-offset-4 decoration-2 text-2xl md:text-3xl font-bold ${
+        pathname === href ? 'text-blue-600' : ''
+      }`}
+    >
+      {label}
+    </Link>
+  );
+
+  return (
+    <header className="fixed top-0 left-0 w-full z-10 px-4 md:px-6 py-4 flex items-center justify-between bg-transparent">
+      <Link href="/" className="text-3xl font-extrabold">Metaswap</Link>
+      <nav className="hidden md:flex items-center gap-8">
+        {links.map((link) => (
+          <NavLink key={link.href} {...link} />
+        ))}
       </nav>
+      <button className="md:hidden" onClick={() => setOpen(true)} aria-label="Open menu">
+        <Bars3Icon className="h-8 w-8" />
+      </button>
+      {open && (
+        <div className="fixed inset-0 bg-black text-white flex flex-col items-center justify-center gap-8">
+          {links.map((link) => (
+            <NavLink key={link.href} {...link} />
+          ))}
+          <button className="absolute top-4 right-4" aria-label="Close menu" onClick={() => setOpen(false)}>
+            <XMarkIcon className="h-8 w-8" />
+          </button>
+        </div>
+      )}
     </header>
   );
 }

--- a/src/app/investors/page.tsx
+++ b/src/app/investors/page.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Investors | Metaswap',
+};
+
+export default function InvestorsPage() {
+  return (
+    <main className="min-h-screen flex items-center justify-center bg-white">
+      <h1 className="text-6xl font-extrabold">Investors</h1>
+    </main>
+  );
+}

--- a/src/app/legal/page.tsx
+++ b/src/app/legal/page.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Legal | Metaswap',
+};
+
+export default function LegalPage() {
+  return (
+    <main className="min-h-screen flex items-center justify-center bg-white">
+      <h1 className="text-6xl font-extrabold">Legal</h1>
+    </main>
+  );
+}

--- a/src/app/news/page.tsx
+++ b/src/app/news/page.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'News | Metaswap',
+};
+
+export default function NewsPage() {
+  return (
+    <main className="min-h-screen flex items-center justify-center bg-white">
+      <h1 className="text-6xl font-extrabold">News</h1>
+    </main>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,9 @@
 // src/app/page.tsx
 
 import SplashScreen from "./splash-screen";
-import ThreeCanvas from "./three-canvas";
+import dynamic from "next/dynamic";
+
+const ThreeCanvas = dynamic(() => import("./three-canvas"), { ssr: false });
 import Header from "./components/Header";
 import Footer from "./components/Footer";
 

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Privacy | Metaswap',
+};
+
+export default function PrivacyPage() {
+  return (
+    <main className="min-h-screen flex items-center justify-center bg-white">
+      <h1 className="text-6xl font-extrabold">Privacy</h1>
+    </main>
+  );
+}

--- a/src/lib/blog.ts
+++ b/src/lib/blog.ts
@@ -1,0 +1,37 @@
+import fs from 'fs/promises';
+import path from 'path';
+
+export interface BlogPost {
+  slug: string;
+  title: string;
+  date: string;
+  excerpt: string;
+  body: string[];
+}
+
+const BLOG_DIR = path.join(process.cwd(), 'content', 'blog');
+
+export async function getAllPosts(): Promise<BlogPost[]> {
+  const files = await fs.readdir(BLOG_DIR);
+  const posts = await Promise.all(
+    files.filter(f => f.endsWith('.json')).map(async (file) => {
+      const data = await fs.readFile(path.join(BLOG_DIR, file), 'utf-8');
+      return JSON.parse(data) as BlogPost;
+    })
+  );
+  return posts.sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
+}
+
+export async function getPostBySlug(slug: string): Promise<BlogPost | null> {
+  try {
+    const data = await fs.readFile(path.join(BLOG_DIR, `${slug}.json`), 'utf-8');
+    return JSON.parse(data) as BlogPost;
+  } catch {
+    return null;
+  }
+}
+
+export async function getAllSlugs(): Promise<string[]> {
+  const files = await fs.readdir(BLOG_DIR);
+  return files.map(f => path.parse(f).name);
+}


### PR DESCRIPTION
## Summary
- build JSON-driven blog listing and post pages
- wire top navigation to new pages and highlight active link
- add placeholder pages for News, Investors, Careers, Legal and Privacy
- load 3D canvas with dynamic import for better performance

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration)*