### PR TITLE
Remove redundant PostCSS config

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,6 +1,0 @@
-module.exports = {
-  plugins: {
-    tailwindcss: {},
-    autoprefixer: {},
-  },
-};

--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -2,6 +2,7 @@
 const config = {
   plugins: {
     tailwindcss: {},
+    autoprefixer: {},
   },
 };
 


### PR DESCRIPTION
## Summary
- keep `postcss.config.mjs` as the single PostCSS config
- add autoprefixer plugin to the remaining config
- delete old `postcss.config.js`

## Testing
- `npm run lint` *(fails: prompts for ESLint setup)*
- `npm run build` *(fails: network access needed for fonts)*