### PR TITLE
Pin ESLint to v8

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@types/react-dom": "^19",
     "@types/three": "^0.171.0",
     "autoprefixer": "^10.4.20",
-    "eslint": "^9",
+    "eslint": "^8.57.0",
     "eslint-config-next": "15.1.3",
     "next-transpile-modules": "^10.0.1",
     "postcss": "^8.4.49",


### PR DESCRIPTION
## Summary
- use ESLint v8 in devDependencies

## Testing
- `npm install` *(fails: unable to reach registry)*