### PR TITLE
Fix layout to allow scrolling on all pages except home

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,5 +1,3 @@
-import Header from '../components/Header';
-import Footer from '../components/Footer';
 import Image from 'next/image';
 import type { Metadata } from 'next';
 
@@ -43,21 +41,19 @@ const values = [
 
 export default function AboutPage() {
   return (
-    <main className="relative min-h-screen w-full bg-white text-black flex flex-col">
-      <Header />
-      <section className="flex-1 px-6 py-24 max-w-6xl mx-auto space-y-16">
-        <div>
-          <h1 className="text-5xl font-extrabold mb-6">About Metaswap</h1>
-          <p className="text-lg leading-relaxed">
-            Metaswap, LLC was founded to empower businesses with modern software solutions.
-            Our mission is to remove the barriers between ideas and scalable infrastructure.
-            We envision a world where anyone can deploy innovative products in minutes.
-          </p>
-        </div>
+    <div className="py-16 px-4 md:px-8 max-w-6xl mx-auto space-y-16">
+      <div>
+        <h1 className="text-5xl font-extrabold mb-6">About Metaswap</h1>
+        <p className="text-lg leading-relaxed">
+          Metaswap, LLC was founded to empower businesses with modern software solutions.
+          Our mission is to remove the barriers between ideas and scalable infrastructure.
+          We envision a world where anyone can deploy innovative products in minutes.
+        </p>
+      </div>
 
-        <div>
-          <h2 className="text-3xl font-bold mb-4">Our Team</h2>
-          <div className="grid gap-8 md:grid-cols-3">
+      <div>
+        <h2 className="text-3xl font-bold mb-4">Our Team</h2>
+        <div className="grid gap-8 md:grid-cols-3">
             {team.map((member) => (
               <div key={member.name} className="text-center border p-4 shadow-sm">
                 <Image
@@ -83,10 +79,8 @@ export default function AboutPage() {
                 {val}
               </div>
             ))}
-          </div>
         </div>
-      </section>
-      <Footer />
-    </main>
+      </div>
+    </div>
   );
 }

--- a/src/app/blog/[slug_title]/page.tsx
+++ b/src/app/blog/[slug_title]/page.tsx
@@ -20,7 +20,7 @@ export default async function BlogPostPage({ params }: { params: { slug_title: s
   if (!post) return notFound();
 
   return (
-    <main className="min-h-screen w-full px-6 py-20 bg-white text-black">
+    <div className="py-16 px-4 md:px-8 max-w-3xl mx-auto">
       <Link href="/blog" className="underline mb-8 block">Back to Blog</Link>
       <h1 className="text-6xl font-extrabold mb-4">{post.title}</h1>
       <p className="text-sm mb-8">{post.date}</p>
@@ -29,6 +29,6 @@ export default async function BlogPostPage({ params }: { params: { slug_title: s
           <p key={idx}>{paragraph}</p>
         ))}
       </article>
-    </main>
+    </div>
   );
 }

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -9,7 +9,7 @@ export const metadata: Metadata = {
 export default async function BlogPage() {
   const posts = await getAllPosts();
   return (
-    <main className="min-h-screen w-full px-6 py-20 bg-white text-black">
+    <div className="py-16 px-4 md:px-8 max-w-6xl mx-auto">
       <h1 className="text-6xl font-extrabold mb-12">Blog</h1>
       <div className="grid gap-8 md:grid-cols-2">
         {posts.map((post) => (
@@ -24,6 +24,6 @@ export default async function BlogPage() {
           </Link>
         ))}
       </div>
-    </main>
+    </div>
   );
 }

--- a/src/app/careers/[slug]/page.tsx
+++ b/src/app/careers/[slug]/page.tsx
@@ -1,5 +1,3 @@
-import Header from '../../components/Header';
-import Footer from '../../components/Footer';
 import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 
@@ -21,16 +19,12 @@ export default function RolePage({ params }: { params: { slug: string } }) {
   const role = roles.find((r) => r.slug === params.slug);
   if (!role) return notFound();
   return (
-    <main className="relative min-h-screen w-full bg-white text-black flex flex-col">
-      <Header />
-      <section className="flex-1 px-6 py-24 max-w-4xl mx-auto space-y-6">
-        <h1 className="text-4xl font-extrabold">{role.title}</h1>
-        <p>{role.description}</p>
-        <a href="mailto:hr@metaswap.xyz" className="underline text-blue-600 font-bold">
-          Apply Now
-        </a>
-      </section>
-      <Footer />
-    </main>
+    <div className="py-16 px-4 md:px-8 max-w-4xl mx-auto space-y-6">
+      <h1 className="text-4xl font-extrabold">{role.title}</h1>
+      <p>{role.description}</p>
+      <a href="mailto:hr@metaswap.xyz" className="underline text-blue-600 font-bold">
+        Apply Now
+      </a>
+    </div>
   );
 }

--- a/src/app/careers/page.tsx
+++ b/src/app/careers/page.tsx
@@ -1,5 +1,3 @@
-import Header from '../components/Header';
-import Footer from '../components/Footer';
 import Link from 'next/link';
 import type { Metadata } from 'next';
 
@@ -17,12 +15,10 @@ const perks = ['Remote friendly', 'Flexible schedule', 'Annual company retreat']
 
 export default function CareersPage() {
   return (
-    <main className="relative min-h-screen w-full bg-white text-black flex flex-col">
-      <Header />
-      <section className="flex-1 px-6 py-24 max-w-6xl mx-auto space-y-16">
-        <div>
-          <h1 className="text-5xl font-extrabold mb-6">Careers</h1>
-          <p className="text-lg mb-8">We\'re looking for talented people to join us on our mission.</p>
+    <div className="py-16 px-4 md:px-8 max-w-6xl mx-auto space-y-16">
+      <div>
+        <h1 className="text-5xl font-extrabold mb-6">Careers</h1>
+          <p className="text-lg mb-8">We&apos;re looking for talented people to join us on our mission.</p>
           <div className="space-y-6">
             {roles.map((role) => (
               <Link
@@ -54,8 +50,6 @@ export default function CareersPage() {
             <button type="submit" className="bg-blue-600 text-white px-4 py-2 font-bold">Sign Up</button>
           </form>
         </div>
-      </section>
-      <Footer />
-    </main>
-  );
-}
+      </div>
+    );
+  }

--- a/src/app/investors/page.tsx
+++ b/src/app/investors/page.tsx
@@ -1,5 +1,3 @@
-import Header from '../components/Header';
-import Footer from '../components/Footer';
 import type { Metadata } from 'next';
 
 export const metadata: Metadata = {
@@ -20,11 +18,9 @@ const faqs = [
 
 export default function InvestorsPage() {
   return (
-    <main className="relative min-h-screen w-full bg-white text-black flex flex-col">
-      <Header />
-      <section className="flex-1 px-6 py-24 max-w-6xl mx-auto space-y-16">
-        <div>
-          <h1 className="text-5xl font-extrabold mb-6">Investor Relations</h1>
+    <div className="py-16 px-4 md:px-8 max-w-6xl mx-auto space-y-16">
+      <div>
+        <h1 className="text-5xl font-extrabold mb-6">Investor Relations</h1>
           <p className="text-lg">Metaswap has grown steadily since its inception and continues to expand its offerings and customer base.</p>
           <div className="grid grid-cols-2 gap-6 mt-8">
             <div className="p-4 border text-center">
@@ -62,9 +58,7 @@ export default function InvestorsPage() {
               </details>
             ))}
           </div>
-        </div>
-      </section>
-      <Footer />
-    </main>
+      </div>
+    </div>
   );
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,8 @@
 import "./globals.css";
 import type { Metadata } from "next";
 import { Orbitron } from "next/font/google";
-import SplashScreen from "./splash-screen";
+import Header from "./components/Header";
+import Footer from "./components/Footer";
 
 const orbitron = Orbitron({
   weight: ["400", "500", "600", "700", "800", "900"],
@@ -16,18 +17,14 @@ export const metadata: Metadata = {
   viewport: "width=device-width, initial-scale=1, viewport-fit=cover",
 };
 
-export default function RootLayout({
-  children,
-}: {
-  children: React.ReactNode;
-}) {
+export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">
-      <body
-        className={`flex flex-col min-h-screen ${orbitron.variable} font-orbitron `}
-      >
-        {children}
-        <SplashScreen />
+      <head />
+      <body className={`min-h-screen flex flex-col ${orbitron.variable} font-orbitron`}>
+        <Header />
+        <main className="flex-1">{children}</main>
+        <Footer />
       </body>
     </html>
   );

--- a/src/app/legal/page.tsx
+++ b/src/app/legal/page.tsx
@@ -6,8 +6,8 @@ export const metadata: Metadata = {
 
 export default function LegalPage() {
   return (
-    <main className="min-h-screen flex items-center justify-center bg-white">
+    <div className="py-16 px-4 md:px-8 text-center">
       <h1 className="text-6xl font-extrabold">Legal</h1>
-    </main>
+    </div>
   );
 }

--- a/src/app/news/page.tsx
+++ b/src/app/news/page.tsx
@@ -1,5 +1,3 @@
-import Header from '../components/Header';
-import Footer from '../components/Footer';
 import { getAllPosts } from '@/lib/blog';
 import Image from 'next/image';
 import Link from 'next/link';
@@ -14,12 +12,10 @@ export default async function NewsPage() {
   const posts = await getAllPosts();
 
   return (
-    <main className="relative min-h-screen w-full bg-white text-black flex flex-col">
-      <Header />
-      <section className="flex-1 px-6 py-24 max-w-6xl mx-auto">
-        <h1 className="text-5xl font-extrabold mb-12">News</h1>
-        <div className="grid gap-8 md:grid-cols-2">
-          {posts.map((post) => (
+    <div className="py-16 px-4 md:px-8 max-w-6xl mx-auto">
+      <h1 className="text-5xl font-extrabold mb-12">News</h1>
+      <div className="grid gap-8 md:grid-cols-2">
+        {posts.map((post) => (
             <Link
               key={post.slug}
               href={`/blog/${post.slug}`}
@@ -41,21 +37,19 @@ export default async function NewsPage() {
             </Link>
           ))}
         </div>
-        <div className="mt-16 text-center">
-          <p className="text-xl font-semibold mb-4">Stay up to date with our latest news.</p>
-          <form className="flex justify-center gap-2">
-            <input
-              type="email"
-              placeholder="Your email"
-              className="border border-gray-300 px-4 py-2 w-64"
-            />
-            <button type="submit" className="bg-blue-600 text-white px-4 py-2 font-bold">
-              Subscribe
-            </button>
-          </form>
-        </div>
-      </section>
-      <Footer />
-    </main>
+      <div className="mt-16 text-center">
+        <p className="text-xl font-semibold mb-4">Stay up to date with our latest news.</p>
+        <form className="flex justify-center gap-2">
+          <input
+            type="email"
+            placeholder="Your email"
+            className="border border-gray-300 px-4 py-2 w-64"
+          />
+          <button type="submit" className="bg-blue-600 text-white px-4 py-2 font-bold">
+            Subscribe
+          </button>
+        </form>
+      </div>
+    </div>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,17 +4,12 @@ import SplashScreen from "./splash-screen";
 import dynamic from "next/dynamic";
 
 const ThreeCanvas = dynamic(() => import("./three-canvas"), { ssr: false });
-import Header from "./components/Header";
-import Footer from "./components/Footer";
 
 export default function HomePage() {
   return (
     <main className="relative w-full h-screen overflow-hidden">
       {/* Splash screen fades out after load */}
       <SplashScreen />
-
-      {/* Header (now set to handle mobile vs. desktop positioning) */}
-      <Header />
 
       {/* Background gradient div (optional) */}
       <div className="absolute inset-0 bg-gradient-to-r from-pink-500 to-blue-500" />
@@ -23,9 +18,6 @@ export default function HomePage() {
       <section className="relative w-full h-full flex items-center justify-center">
         <ThreeCanvas />
       </section>
-
-      {/* Footer with brand & links */}
-      <Footer />
     </main>
   );
 }

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -6,8 +6,8 @@ export const metadata: Metadata = {
 
 export default function PrivacyPage() {
   return (
-    <main className="min-h-screen flex items-center justify-center bg-white">
+    <div className="py-16 px-4 md:px-8 text-center">
       <h1 className="text-6xl font-extrabold">Privacy</h1>
-    </main>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- update global layout with Header/Footer
- keep fullscreen styling in home page
- remove fixed main wrappers from content pages
- ensure blog and legal pages use scrollable layout

## Testing
- `npm run lint`