### PR TITLE
Fix homepage full-bleed layout

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,9 @@
+"use client";
+
 import "./globals.css";
 import type { Metadata } from "next";
 import { Orbitron } from "next/font/google";
+import { usePathname } from "next/navigation";
 import Header from "./components/Header";
 import Footer from "./components/Footer";
 
@@ -18,13 +21,22 @@ export const metadata: Metadata = {
 };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
+  const path = usePathname();
+  const isHome = path === "/";
+
   return (
     <html lang="en">
       <head />
       <body className={`min-h-screen flex flex-col ${orbitron.variable} font-orbitron`}>
         <Header />
-        <main className="flex-1">{children}</main>
-        <Footer />
+        <main
+          className={
+            isHome ? "fixed inset-0 overflow-hidden" : "flex-1 overflow-auto px-4 md:px-8"
+          }
+        >
+          {children}
+        </main>
+        {!isHome && <Footer />}
       </body>
     </html>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,7 +7,7 @@ const ThreeCanvas = dynamic(() => import("./three-canvas"), { ssr: false });
 
 export default function HomePage() {
   return (
-    <main className="relative w-full h-screen overflow-hidden">
+    <main className="fixed inset-0 overflow-hidden">
       {/* Splash screen fades out after load */}
       <SplashScreen />
 


### PR DESCRIPTION
## Summary
- make home container fixed to span entire viewport
- adjust global layout to only pad non-home pages

## Testing
- `npm run lint`
